### PR TITLE
fix: handling debian and debian-security

### DIFF
--- a/define/debian.go
+++ b/define/debian.go
@@ -6,7 +6,7 @@ const (
 	DEBIAN_BENCHMAKR_URL = "dists/bullseye/main/binary-amd64/Release"
 )
 
-var DEBIAN_HOST_PATTERN = regexp.MustCompile(`/debian/(.+)$`)
+var DEBIAN_HOST_PATTERN = regexp.MustCompile(`/debian(-security)?/(.+)$`)
 
 // https://www.debian.org/mirror/list 2022.11.19
 // Sites that contain protocol headers, restrict access to resources using that protocol

--- a/internal/rewriter/rewriter.go
+++ b/internal/rewriter/rewriter.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/soulteary/apt-proxy/define"
@@ -171,6 +172,13 @@ func RewriteRequestByMode(r *http.Request, rewriters *URLRewriters, mode int) {
 
 	r.URL.Scheme = rewriter.mirror.Scheme
 	r.URL.Host = rewriter.mirror.Host
+	if mode == define.TYPE_LINUX_DISTROS_DEBIAN {
+		slugs_query := strings.Split(r.URL.Path, "/")
+		slugs_mirror := strings.Split(rewriter.mirror.Path, "/")
+		slugs_mirror[0] = slugs_query[0]
+		r.URL.Path = strings.Join(slugs_query, "/")
+		return
+	}
 	r.URL.Path = rewriter.mirror.Path + unescapedQuery
 }
 


### PR DESCRIPTION
Debian uses two paths, one for main packages, one for security ones.

See #29 