### PR TITLE
Support HTTPS/// in proxy requests

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -198,6 +199,14 @@ func NewPackageStruct(opts Options) (*PackageStruct, error) {
 		Handler: &httputil.ReverseProxy{
 			Director:  func(r *http.Request) {},
 			Transport: transport,
+			ModifyResponse: func(r *http.Response) error {
+				if r.StatusCode == http.StatusFound && r.Request.Header.Get("Rewrite-HTTPS") != "" {
+					l := r.Header.Get("Location")
+					l = strings.Replace(l, "https://", "/HTTPS///", 1)
+					r.Header.Set("Location", l)
+				}
+				return nil
+			},
 		},
 	}
 	return ps, nil

--- a/internal/proxy/transport.go
+++ b/internal/proxy/transport.go
@@ -61,7 +61,7 @@ func (rt *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 
 	// Rewrite HTTPS///
 	if strings.Contains(req.URL.Path, "HTTPS///") {
-		httpsURL, err := url.Parse(strings.Replace(req.URL.Path, "/HTTPS///", "https://", 1))
+		httpsURL, err := url.Parse(strings.Replace(req.URL.RequestURI(), "/HTTPS///", "https://", 1))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/proxy/transport.go
+++ b/internal/proxy/transport.go
@@ -71,6 +71,7 @@ func (rt *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 		httpsReq.Header = req.Header.Clone()
 		httpsReq.Header.Set("Host", httpsReq.Host)
+		httpsReq.Header.Set("Rewrite-HTTPS", "true")
 		req = httpsReq
 	}
 

--- a/internal/proxy/transport.go
+++ b/internal/proxy/transport.go
@@ -17,6 +17,8 @@ package proxy
 import (
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	httpkit "github.com/soulteary/http-kit"
@@ -56,6 +58,21 @@ func NewRetryableTransport(baseTransport http.RoundTripper) *RetryableTransport 
 // a single attempt in that case rather than send a corrupt second request.
 func (rt *RetryableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
+
+	// Rewrite HTTPS///
+	if strings.Contains(req.URL.Path, "HTTPS///") {
+		httpsURL, err := url.Parse(strings.Replace(req.URL.Path, "/HTTPS///", "https://", 1))
+		if err != nil {
+			return nil, err
+		}
+		httpsReq, err := http.NewRequestWithContext(ctx, req.Method, httpsURL.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+		httpsReq.Header = req.Header.Clone()
+		httpsReq.Header.Set("Host", httpsReq.Host)
+		req = httpsReq
+	}
 
 	// Start tracing span
 	spanCtx, span := tracing.StartSpan(ctx, "proxy.upstream.request")


### PR DESCRIPTION
The "HTTPS///" gets replaced with "https://" for the external
adress, to allow using http:// address (and therefore caching).

Closes #57 
