### PR TITLE
fix: run security scan with Go 1.26.6

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -48,11 +48,9 @@ jobs:
           govulncheck ./...
 
       - name: Security Scan
-        # Pinned to gosec v2.28.0 commit SHA to mitigate supply-chain risk.
-        # Update this together with the version comment when bumping.
-        uses: securego/gosec@5bb2909d48fa8072136f38ad329b37575ab15c9f # v2.28.0
-        with:
-          args: '-fmt sarif -out results.sarif ./...'
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.28.0
+          gosec -fmt sarif -out results.sarif ./...
 
       - name: Temp sarif workaround
         if: always()


### PR DESCRIPTION
## Summary

- run gosec with the Go 1.26.6 toolchain already configured by `actions/setup-go`
- pin gosec to v2.28.0 through the Go module installer
- avoid the gosec Docker action's embedded Go 1.25.8 toolchain, which cannot load this module while `GOTOOLCHAIN=local`

## Root cause

After the Fiber v3 migration, `go.mod` requires Go 1.26.6. The gosec v2.28.0 Docker action is built on Go 1.25.8, and GitHub Actions passes `GOTOOLCHAIN=local` into that container. The scanner therefore exits before completing package analysis even though the host job has Go 1.26.6 configured.

## Validation

- `govulncheck ./...`: no reachable vulnerabilities
- `gosec v2.28.0 -fmt text ./...`: 0 issues
- `go vet ./...`
- `go test -run '^$' ./...`
