### PR TITLE
fix: preserve YAML API auth tri-state semantics

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -119,6 +119,46 @@ mode: "ubuntu"
 	}
 }
 
+func TestLoadConfigFileAPIAuthTriState(t *testing.T) {
+	tests := []struct {
+		name        string
+		toggle      string
+		wantEnabled bool
+	}{
+		{
+			name:        "API key implicitly enables auth when toggle is omitted",
+			wantEnabled: true,
+		},
+		{
+			name:        "explicit false disables auth",
+			toggle:      "  enable_api_auth: false\n",
+			wantEnabled: false,
+		},
+		{
+			name:        "explicit true enables auth",
+			toggle:      "  enable_api_auth: true\n",
+			wantEnabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "apt-proxy.yaml")
+			content := "security:\n  api_key: test-api-key\n" + tt.toggle
+			if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			cfg, err := LoadConfigFile(path)
+			if err != nil {
+				t.Fatalf("LoadConfigFile: %v", err)
+			}
+			if cfg.Security.EnableAPIAuth != tt.wantEnabled {
+				t.Fatalf("EnableAPIAuth = %v, want %v", cfg.Security.EnableAPIAuth, tt.wantEnabled)
+			}
+		})
+	}
+}
+
 func TestLoadConfigFile_NotFound(t *testing.T) {
 	cfg, err := LoadConfigFile("/nonexistent/path/config.yaml")
 	if err != nil {

--- a/internal/config/loader_yaml.go
+++ b/internal/config/loader_yaml.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -56,8 +57,10 @@ type YAMLConfig struct {
 	} `yaml:"tls"`
 
 	Security struct {
-		APIKey                string   `yaml:"api_key"`
-		EnableAPIAuth         bool     `yaml:"enable_api_auth"`
+		APIKey string `yaml:"api_key"`
+		// Pointer preserves the distinction between an omitted value (API key
+		// implies authentication) and an explicit false override.
+		EnableAPIAuth         *bool    `yaml:"enable_api_auth"`
 		APIRateLimitPerMinute int      `yaml:"api_rate_limit_per_minute"`
 		TrustedProxies        []string `yaml:"trusted_proxies"`
 	} `yaml:"security"`
@@ -152,6 +155,11 @@ func expandConfigEnv(src string) string {
 
 // yamlConfigToConfig converts a YAMLConfig to the internal Config structure.
 func yamlConfigToConfig(yamlCfg *YAMLConfig) *Config {
+	enableAPIAuth := strings.TrimSpace(yamlCfg.Security.APIKey) != ""
+	if yamlCfg.Security.EnableAPIAuth != nil {
+		enableAPIAuth = *yamlCfg.Security.EnableAPIAuth
+	}
+
 	cfg := &Config{
 		Debug:    yamlCfg.Server.Debug,
 		CacheDir: yamlCfg.Cache.Dir,
@@ -174,7 +182,7 @@ func yamlConfigToConfig(yamlCfg *YAMLConfig) *Config {
 		},
 		Security: SecurityConfig{
 			APIKey:                yamlCfg.Security.APIKey,
-			EnableAPIAuth:         yamlCfg.Security.EnableAPIAuth,
+			EnableAPIAuth:         enableAPIAuth,
 			APIRateLimitPerMinute: yamlCfg.Security.APIRateLimitPerMinute,
 			TrustedProxies:        append([]string(nil), yamlCfg.Security.TrustedProxies...),
 		},


### PR DESCRIPTION
## Summary

Follow-up to #75 and its automated review feedback.

- represent YAML `security.enable_api_auth` as a pointer so omitted and explicit false values remain distinguishable
- make a non-empty YAML `api_key` implicitly enable authentication when the toggle is omitted
- continue honoring an explicit `enable_api_auth: false`
- add table-driven regression coverage for omitted, explicit false, and explicit true states

This restores the documented behavior without weakening the fail-closed management API introduced in #75.

## Verification

- `go test ./...`
- `go test -race ./internal/config ./internal/cli`
- `go vet ./...`