### PR TITLE
chore: upgrade httpcache-kit to v2.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/soulteary/cli-kit v1.7.0
 	github.com/soulteary/health-kit/v2 v2.0.0-20260825184657-5abf6d7d57aa
 	github.com/soulteary/http-kit v1.2.0
-	github.com/soulteary/httpcache-kit/v2 v2.0.1-0.20260826061340-f94527052973
+	github.com/soulteary/httpcache-kit/v2 v2.0.1
 	github.com/soulteary/logger-kit/v2 v2.0.0
 	github.com/soulteary/metrics-kit/v2 v2.0.0
 	github.com/soulteary/middleware-kit/v2 v2.0.0-20260825190703-ab8d8cfae74a

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/soulteary/health-kit/v2 v2.0.0-20260825184657-5abf6d7d57aa h1:E6XP7wr
 github.com/soulteary/health-kit/v2 v2.0.0-20260825184657-5abf6d7d57aa/go.mod h1:OfSD52DUlA6HpDLN1ELAyqQk0xaycosbXlCsEpafZCQ=
 github.com/soulteary/http-kit v1.2.0 h1:Nq7McLtpzhZS53mE7WR0geArGvSnZDotMOe3Z8RnRHU=
 github.com/soulteary/http-kit v1.2.0/go.mod h1:EIlpxL+IpPwMnKYvdfqtXI1e48d1FkQQ/6ASnnD8Q/g=
-github.com/soulteary/httpcache-kit/v2 v2.0.1-0.20260826061340-f94527052973 h1:ocNp3/wJGr9V/t2UGaTmiHwr4vnWvPHYpWm5FgfGTYc=
-github.com/soulteary/httpcache-kit/v2 v2.0.1-0.20260826061340-f94527052973/go.mod h1:M3fhSKnnrbmVQNw9idbqjudzE1s8H6fR8Ayg5cT2zR0=
+github.com/soulteary/httpcache-kit/v2 v2.0.1 h1:TS8W5SHuSmcH3C5/0Je8l8mPmBWyr+kdFTypDEHgfjA=
+github.com/soulteary/httpcache-kit/v2 v2.0.1/go.mod h1:M3fhSKnnrbmVQNw9idbqjudzE1s8H6fR8Ayg5cT2zR0=
 github.com/soulteary/logger-kit/v2 v2.0.0 h1:VWc9uU8b7OCQC+4lckGeBrbtL8DYXo4duM8B1UYiQpA=
 github.com/soulteary/logger-kit/v2 v2.0.0/go.mod h1:Z653e2gcefSA5uVs3sP1dEE++kzLBPnhEbLbxpkUktQ=
 github.com/soulteary/metrics-kit/v2 v2.0.0 h1:cYEKlhSdPT08xUFP5vspF4Ud2+AxdderYLY/zhlBcqE=


### PR DESCRIPTION
## Summary

- replace the temporary `httpcache-kit/v2` pseudo-version used while the P0/P1 fixes were under review with the official `v2.0.1` release
- refresh module checksums and remove the obsolete pseudo-version entries
- keep the dependency graph otherwise unchanged

This completes the release handoff from soulteary/httpcache-kit#4 and preserves the cache-safety fixes already integrated in apt-proxy.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`