### PR TITLE
chore: upgrade to Go 1.27 and Alpine 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.27.0"
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -110,6 +110,17 @@ jobs:
           GOOS=linux   GOARCH=arm   GOARM=7      go build -trimpath -o /tmp/apt-proxy-linux-armv7   ./cmd/apt-proxy
           GOOS=darwin  GOARCH=amd64              go build -trimpath -o /tmp/apt-proxy-darwin-amd64  ./cmd/apt-proxy
           GOOS=darwin  GOARCH=arm64              go build -trimpath -o /tmp/apt-proxy-darwin-arm64  ./cmd/apt-proxy
+
+  container:
+    name: Container
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build container image
+        run: docker build --file docker/Dockerfile --tag apt-proxy:test .
 
   integration:
     name: Integration (e2e)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
-          version: v2.12.2
+          version: v2.13.1
           args: --timeout=5m
 
       - name: go vet

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.27.0"
 
 jobs:
   build:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.6"
+  GO_VERSION: "1.27.0"
 
 jobs:
   scan:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.6-alpine3.23 AS builder
+FROM golang:1.27.0-alpine3.24 AS builder
 RUN apk add --no-cache ca-certificates tzdata git
 ARG TZ=Asia/Shanghai
 ENV TZ=${TZ}
@@ -16,7 +16,7 @@ RUN go build -trimpath \
     -ldflags "-s -w -X 'main.version=${VERSION}' -X 'main.commit=${COMMIT}' -X 'main.date=${DATE}'" \
     -o /out/apt-proxy ./cmd/apt-proxy
 
-FROM alpine:3.23
+FROM alpine:3.24
 RUN apk add --no-cache ca-certificates tzdata wget && \
     addgroup -g 1000 aptproxy && \
     adduser -D -u 1000 -G aptproxy aptproxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/soulteary/apt-proxy
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/gofiber/fiber/v3 v3.5.0

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -196,7 +196,7 @@ func NewPackageStruct(opts Options) (*PackageStruct, error) {
 		bench:     bench,
 		transport: transport,
 		Handler: &httputil.ReverseProxy{
-			Director:  func(r *http.Request) {},
+			Rewrite:   func(*httputil.ProxyRequest) {},
 			Transport: transport,
 		},
 	}


### PR DESCRIPTION
## Summary

- raise the module Go version from `1.26.6` to `1.27.0`
- align CI, security scanning, and release workflows on Go `1.27.0`
- upgrade the source-build container to `golang:1.27.0-alpine3.24`
- upgrade the runtime container to `alpine:3.24`
- upgrade golangci-lint from `v2.12.2` to Go 1.27-compatible `v2.13.1`
- replace deprecated `ReverseProxy.Director` with `Rewrite`
- add a pull-request container build so future Dockerfile and base-image changes are validated before merge

The Go and Alpine image tags are available as official Docker images. The GoReleaser image remains on its existing distroless runtime and is intentionally unchanged.

## Verification

- Go `1.27.0` toolchain bootstrapped successfully
- golangci-lint `v2.13.1`: `0 issues`
- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build -trimpath ./cmd/apt-proxy`
- `git diff --check`
- old Go `1.26.6` and Alpine `3.23` references removed