### PR TITLE
fix: use dedicated mirrors for Ubuntu Ports

### DIFF
--- a/internal/mirrors/mirrors.go
+++ b/internal/mirrors/mirrors.go
@@ -73,24 +73,6 @@ var builtinByMode = map[int]builtinDistro{
 // for the given proxy mode. When reg is non-nil, registry-loaded
 // mirrors are preferred over the compile-time built-ins.
 func GetGeoMirrorUrlsByMode(reg *distro.Registry, mode int) (mirrors []string) {
-	// Ubuntu/UbuntuPorts: prefer geo-derived mirrors (real point of the
-	// `mirrors.txt` lookup). Fall back to registry/built-in on failure so
-	// the proxy still has *some* upstream list when the geo API is down.
-	if mode == distro.TypeUbuntu || mode == distro.TypeUbuntuPorts {
-		online, err := GetUbuntuMirrorUrlsByGeo()
-		if err == nil && len(online) > 0 {
-			if mode == distro.TypeUbuntu {
-				return online
-			}
-			results := make([]string, 0, len(online))
-			for _, m := range online {
-				results = append(results, strings.ReplaceAll(m, "/ubuntu/", "/ubuntu-ports/"))
-			}
-			return results
-		}
-		// Geo failed: fall through to registry/built-in.
-	}
-
 	// Prefer registry (config-loaded) mirrors when present
 	if reg != nil {
 		if d, ok := reg.GetByType(mode); ok && len(d.Mirrors) > 0 {
@@ -101,6 +83,17 @@ func GetGeoMirrorUrlsByMode(reg *distro.Registry, mode int) (mirrors []string) {
 				return mirrors
 			}
 		}
+	}
+
+	// Ubuntu's mirrors.txt endpoint lists archive mirrors. It does not
+	// guarantee that those hosts also publish the distinct ubuntu-ports
+	// archive, so only use geo-discovered candidates for regular Ubuntu.
+	if mode == distro.TypeUbuntu {
+		online, err := GetUbuntuMirrorUrlsByGeo()
+		if err == nil && len(online) > 0 {
+			return online
+		}
+		// Geo failed: fall through to the built-in archive mirrors.
 	}
 
 	// Other single-distro modes: just return their built-in list.

--- a/internal/mirrors/mirrors_test.go
+++ b/internal/mirrors/mirrors_test.go
@@ -15,11 +15,44 @@
 package mirrors
 
 import (
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/soulteary/apt-proxy/internal/distro"
 )
+
+func TestUbuntuPortsUsesRegistryMirrors(t *testing.T) {
+	reg := distro.NewRegistry()
+	want := []string{
+		"https://ports-one.example.com/ubuntu-ports/",
+		"https://ports-two.example.com/ubuntu-ports/",
+	}
+	if err := reg.Register(&distro.RegisteredDistribution{
+		ID:         "ubuntu-ports",
+		Name:       "Ubuntu Ports",
+		Type:       distro.TypeUbuntuPorts,
+		URLPattern: regexp.MustCompile(`/ubuntu-ports/`),
+		Mirrors: []distro.URLWithAlias{
+			{URL: want[0], Scheme: "https"},
+			{URL: want[1], Scheme: "https"},
+		},
+	}); err != nil {
+		t.Fatalf("register ubuntu ports: %v", err)
+	}
+
+	if got := GetGeoMirrorUrlsByMode(reg, distro.TypeUbuntuPorts); !reflect.DeepEqual(got, want) {
+		t.Fatalf("configured Ubuntu Ports mirrors = %v, want %v", got, want)
+	}
+}
+
+func TestUbuntuPortsUsesDedicatedBuiltins(t *testing.T) {
+	want := builtinMirrorURLs(distro.BuiltinUbuntuPortsMirrors)
+	if got := GetGeoMirrorUrlsByMode(nil, distro.TypeUbuntuPorts); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Ubuntu Ports mirrors = %v, want dedicated built-ins %v", got, want)
+	}
+}
 
 func TestGetUbuntuMirrorByAliases(t *testing.T) {
 	alias := GetMirrorURLByAliases(nil, distro.TypeUbuntu, "cn:tsinghua")

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -15,11 +15,14 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -39,6 +42,57 @@ const (
 	DefaultIdleConnTimeout       = 90 * time.Second
 	DefaultMaxIdleConns          = 100
 )
+
+func detachRequest(r *http.Request, ctx context.Context) *http.Request {
+	detached := r.Clone(ctx)
+	detached.Method = strings.Clone(detached.Method)
+	detached.Host = strings.Clone(detached.Host)
+	detached.RemoteAddr = strings.Clone(detached.RemoteAddr)
+	detached.RequestURI = strings.Clone(detached.RequestURI)
+
+	if detached.URL != nil {
+		u := *detached.URL
+		u.Scheme = strings.Clone(u.Scheme)
+		u.Opaque = strings.Clone(u.Opaque)
+		u.Host = strings.Clone(u.Host)
+		u.Path = strings.Clone(u.Path)
+		u.RawPath = strings.Clone(u.RawPath)
+		u.RawQuery = strings.Clone(u.RawQuery)
+		u.Fragment = strings.Clone(u.Fragment)
+		u.RawFragment = strings.Clone(u.RawFragment)
+		if u.User != nil {
+			username := strings.Clone(u.User.Username())
+			if password, ok := u.User.Password(); ok {
+				u.User = url.UserPassword(username, strings.Clone(password))
+			} else {
+				u.User = url.User(username)
+			}
+		}
+		detached.URL = &u
+	}
+
+	detached.Header = detachHeader(detached.Header)
+	detached.Trailer = detachHeader(detached.Trailer)
+	for i := range detached.TransferEncoding {
+		detached.TransferEncoding[i] = strings.Clone(detached.TransferEncoding[i])
+	}
+	return detached
+}
+
+func detachHeader(header http.Header) http.Header {
+	if header == nil {
+		return nil
+	}
+	detached := make(http.Header, len(header))
+	for key, values := range header {
+		cloned := make([]string, len(values))
+		for i, value := range values {
+			cloned[i] = strings.Clone(value)
+		}
+		detached[strings.Clone(key)] = cloned
+	}
+	return detached
+}
 
 // hostPatternEntry pairs a compiled URL pattern with its rules and is used
 // instead of map[*regexp.Regexp][]Rule on the request hot path. A slice
@@ -267,7 +321,11 @@ func (ap *PackageStruct) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		"http.remote_addr": r.RemoteAddr,
 	})
 
-	r = r.WithContext(spanCtx)
+	// Fiber/fasthttp reuses its request buffers after ServeHTTP returns, while
+	// the cache may finish a write asynchronously and retain the request URL as
+	// part of its key. Clone here so background cache work never references
+	// memory that the adapter can reuse for the next request.
+	r = detachRequest(r, spanCtx)
 
 	rule := ap.handleExternalURLs(r)
 	if rule != nil {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -43,7 +43,7 @@ const (
 	DefaultMaxIdleConns          = 100
 )
 
-func detachRequest(r *http.Request, ctx context.Context) *http.Request {
+func detachRequest(ctx context.Context, r *http.Request) *http.Request {
 	detached := r.Clone(ctx)
 	detached.Method = strings.Clone(detached.Method)
 	detached.Host = strings.Clone(detached.Host)
@@ -325,7 +325,7 @@ func (ap *PackageStruct) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// the cache may finish a write asynchronously and retain the request URL as
 	// part of its key. Clone here so background cache work never references
 	// memory that the adapter can reuse for the next request.
-	r = detachRequest(r, spanCtx)
+	r = detachRequest(spanCtx, r)
 
 	rule := ap.handleExternalURLs(r)
 	if rule != nil {

--- a/tests/integration/daemon_e2e_test.go
+++ b/tests/integration/daemon_e2e_test.go
@@ -53,10 +53,18 @@ func freeListenPort(t *testing.T) (string, string) {
 
 func waitForServer(t *testing.T, url string, timeout time.Duration) {
 	t.Helper()
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	defer client.CloseIdleConnections()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(url)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("create readiness request: %v", err)
+		}
+		req.Close = true
+		resp, err := client.Do(req)
 		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 			if resp.StatusCode < 500 {
 				return
@@ -164,12 +172,27 @@ func TestDaemonE2EHealthCheckPersists(t *testing.T) {
 	baseURL := fmt.Sprintf("http://%s:%s", host, port)
 	waitForServer(t, baseURL+"/healthz", 5*time.Second)
 
-	resp, err := http.Get(baseURL + "/healthz")
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/healthz", nil)
+	if err != nil {
+		t.Fatalf("create GET /healthz request: %v", err)
+	}
+	// The test sends SIGTERM before returning. Do not leave its own idle
+	// keep-alive connection open while asserting that Fiber shuts down.
+	req.Close = true
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	defer client.CloseIdleConnections()
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("GET /healthz: %v", err)
 	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		t.Fatalf("read /healthz response: %v", readErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close /healthz response: %v", closeErr)
+	}
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
 	}


### PR DESCRIPTION
## Summary

- honor registry-configured mirrors before dynamic discovery
- use Ubuntu's `mirrors.txt` discovery only for the regular Ubuntu archive
- use configured or built-in Ubuntu Ports mirrors directly
- add regression coverage for configured and built-in Ports candidates
- detach adapted Fiber requests before asynchronous cache writes
- prevent the daemon E2E test from holding its own keep-alive connection during shutdown

Ubuntu archive mirrors are not guaranteed to publish `ubuntu-ports`; replacing `/ubuntu/` with `/ubuntu-ports/` can therefore generate invalid upstream URLs. This extracts the Ubuntu Ports intent from #58 without changing `Range` or HTTP/2 handling.

The request detachment fixes the race reported by CI job 98105170051: fasthttp may reuse zero-copy request strings while httpcache-kit finishes a background cache write. The E2E adjustment uses a no-keepalive test client and closes responses before SIGTERM, avoiding a test-induced graceful-shutdown timeout.

## Verification

- failing production Fiber cache test passes under `go test -race` for 20 consecutive runs
- daemon health/shutdown integration test passes under `-race` for 5 consecutive runs
- `go test -race ./internal/proxy ./internal/cli`
- new Ubuntu Ports race tests pass
- all packages compile
- `go vet ./...`