### PR TITLE
feat: support dedicated Debian Security mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ View all available options:
 | `-ubuntu` | Ubuntu mirror URL or shortcut | (auto-select) |
 | `-ubuntu-ports` | Ubuntu Ports mirror URL or shortcut | (auto-select) |
 | `-debian` | Debian mirror URL or shortcut | (auto-select) |
+| `-debian-security` | Dedicated Debian Security mirror URL or shortcut | (derived from `-debian`) |
 | `-centos` | CentOS mirror URL or shortcut | (auto-select) |
 | `-alpine` | Alpine mirror URL or shortcut | (auto-select) |
 | `-distributions-config` | Path to distributions/mirrors YAML (distributions.yaml) | (optional) |
@@ -366,6 +367,7 @@ Every CLI flag has an equivalent environment variable. Plus a few extras for log
 | `APT_PROXY_UBUNTU` | `-ubuntu` | Ubuntu mirror URL or shortcut |
 | `APT_PROXY_UBUNTU_PORTS` | `-ubuntu-ports` | Ubuntu Ports mirror URL or shortcut |
 | `APT_PROXY_DEBIAN` | `-debian` | Debian mirror URL or shortcut |
+| `APT_PROXY_DEBIAN_SECURITY` | `-debian-security` | Dedicated Debian Security mirror URL or shortcut |
 | `APT_PROXY_CENTOS` | `-centos` | CentOS mirror URL or shortcut |
 | `APT_PROXY_ALPINE` | `-alpine` | Alpine mirror URL or shortcut |
 | `APT_PROXY_UPSTREAM_KEEP_ALIVE` | `-upstream-keep-alive` | HTTP keep-alive to upstream mirrors |
@@ -468,6 +470,7 @@ mirrors:
   ubuntu: cn:tsinghua
   ubuntu_ports: ""
   debian: cn:ustc
+  debian_security: https://mirrors.ustc.edu.cn/debian-security/
   centos: ""
   alpine: ""
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -310,6 +310,7 @@ http_proxy=http://host.docker.internal:3142 \
 | `-ubuntu` | Ubuntu 镜像 URL 或快捷方式 | （自动选择） |
 | `-ubuntu-ports` | Ubuntu Ports 镜像 URL 或快捷方式 | （自动选择） |
 | `-debian` | Debian 镜像 URL 或快捷方式 | （自动选择） |
+| `-debian-security` | 独立的 Debian Security 镜像 URL 或快捷方式 | （从 `-debian` 推导） |
 | `-centos` | CentOS 镜像 URL 或快捷方式 | （自动选择） |
 | `-alpine` | Alpine 镜像 URL 或快捷方式 | （自动选择） |
 | `-distributions-config` | 发行版/镜像配置文件路径（distributions.yaml） | （可选） |
@@ -367,6 +368,7 @@ http_proxy=http://host.docker.internal:3142 \
 | `APT_PROXY_UBUNTU` | `-ubuntu` | Ubuntu 镜像 URL 或快捷方式 |
 | `APT_PROXY_UBUNTU_PORTS` | `-ubuntu-ports` | Ubuntu Ports 镜像 |
 | `APT_PROXY_DEBIAN` | `-debian` | Debian 镜像 |
+| `APT_PROXY_DEBIAN_SECURITY` | `-debian-security` | 独立的 Debian Security 镜像 |
 | `APT_PROXY_CENTOS` | `-centos` | CentOS 镜像 |
 | `APT_PROXY_ALPINE` | `-alpine` | Alpine 镜像 |
 | `APT_PROXY_UPSTREAM_KEEP_ALIVE` | `-upstream-keep-alive` | 上游 HTTP keep-alive |
@@ -468,6 +470,7 @@ mirrors:
   ubuntu: cn:tsinghua
   ubuntu_ports: ""
   debian: cn:ustc
+  debian_security: https://mirrors.ustc.edu.cn/debian-security/
   centos: ""
   alpine: ""
 

--- a/examples/config-template/apt-proxy.yaml
+++ b/examples/config-template/apt-proxy.yaml
@@ -81,6 +81,9 @@ mirrors:
   
   # Debian mirror
   debian: cn:ustc
+
+  # Optional dedicated Debian Security mirror (derived from Debian when empty)
+  debian_security: ""
   
   # CentOS mirror
   centos: ""

--- a/examples/s3-otterio/apt-proxy.yaml
+++ b/examples/s3-otterio/apt-proxy.yaml
@@ -44,3 +44,4 @@ mirrors:
   # Optional: pin upstream mirrors. Empty = auto-benchmark on startup.
   ubuntu: ""
   debian: ""
+  debian_security: ""

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -39,16 +39,17 @@ type (
 
 // Re-export constants from internal/config for backward compatibility
 const (
-	EnvHost        = config.EnvHost
-	EnvPort        = config.EnvPort
-	EnvMode        = config.EnvMode
-	EnvCacheDir    = config.EnvCacheDir
-	EnvDebug       = config.EnvDebug
-	EnvUbuntu      = config.EnvUbuntu
-	EnvUbuntuPorts = config.EnvUbuntuPorts
-	EnvDebian      = config.EnvDebian
-	EnvCentOS      = config.EnvCentOS
-	EnvAlpine      = config.EnvAlpine
+	EnvHost           = config.EnvHost
+	EnvPort           = config.EnvPort
+	EnvMode           = config.EnvMode
+	EnvCacheDir       = config.EnvCacheDir
+	EnvDebug          = config.EnvDebug
+	EnvUbuntu         = config.EnvUbuntu
+	EnvUbuntuPorts    = config.EnvUbuntuPorts
+	EnvDebian         = config.EnvDebian
+	EnvDebianSecurity = config.EnvDebianSecurity
+	EnvCentOS         = config.EnvCentOS
+	EnvAlpine         = config.EnvAlpine
 
 	EnvCacheMaxSize         = config.EnvCacheMaxSize
 	EnvCacheTTL             = config.EnvCacheTTL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,11 +109,12 @@ type TLSConfig struct {
 
 // MirrorConfig holds mirror-specific configuration
 type MirrorConfig struct {
-	Ubuntu      string `yaml:"ubuntu"`
-	UbuntuPorts string `yaml:"ubuntu_ports"`
-	Debian      string `yaml:"debian"`
-	CentOS      string `yaml:"centos"`
-	Alpine      string `yaml:"alpine"`
+	Ubuntu         string `yaml:"ubuntu"`
+	UbuntuPorts    string `yaml:"ubuntu_ports"`
+	Debian         string `yaml:"debian"`
+	DebianSecurity string `yaml:"debian_security"`
+	CentOS         string `yaml:"centos"`
+	Alpine         string `yaml:"alpine"`
 }
 
 // CacheConfig holds cache-specific configuration.

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -16,16 +16,17 @@ package config
 
 // Environment variable names for configuration
 const (
-	EnvHost        = "APT_PROXY_HOST"
-	EnvPort        = "APT_PROXY_PORT"
-	EnvMode        = "APT_PROXY_MODE"
-	EnvCacheDir    = "APT_PROXY_CACHEDIR"
-	EnvDebug       = "APT_PROXY_DEBUG"
-	EnvUbuntu      = "APT_PROXY_UBUNTU"
-	EnvUbuntuPorts = "APT_PROXY_UBUNTU_PORTS"
-	EnvDebian      = "APT_PROXY_DEBIAN"
-	EnvCentOS      = "APT_PROXY_CENTOS"
-	EnvAlpine      = "APT_PROXY_ALPINE"
+	EnvHost           = "APT_PROXY_HOST"
+	EnvPort           = "APT_PROXY_PORT"
+	EnvMode           = "APT_PROXY_MODE"
+	EnvCacheDir       = "APT_PROXY_CACHEDIR"
+	EnvDebug          = "APT_PROXY_DEBUG"
+	EnvUbuntu         = "APT_PROXY_UBUNTU"
+	EnvUbuntuPorts    = "APT_PROXY_UBUNTU_PORTS"
+	EnvDebian         = "APT_PROXY_DEBIAN"
+	EnvDebianSecurity = "APT_PROXY_DEBIAN_SECURITY"
+	EnvCentOS         = "APT_PROXY_CENTOS"
+	EnvAlpine         = "APT_PROXY_ALPINE"
 
 	// Cache configuration environment variables
 	EnvCacheMaxSize         = "APT_PROXY_CACHE_MAX_SIZE"

--- a/internal/config/loader_extra_test.go
+++ b/internal/config/loader_extra_test.go
@@ -46,7 +46,7 @@ func clearConfigEnv(t *testing.T) {
 	for _, v := range []string{
 		EnvHost, EnvPort, EnvCacheDir, EnvMode,
 		EnvCacheMaxSize, EnvCacheTTL, EnvCacheCleanupInterval,
-		EnvDebug, EnvUbuntu, EnvUbuntuPorts, EnvDebian,
+		EnvDebug, EnvUbuntu, EnvUbuntuPorts, EnvDebian, EnvDebianSecurity,
 		EnvCentOS, EnvAlpine,
 		EnvAPIKey, EnvAPIRateLimitPerMinute, EnvEnableAPIAuth, EnvTrustedProxies,
 		EnvUpstreamKeepAlive, EnvDistributionsConfig,
@@ -77,6 +77,20 @@ func TestParseFlagsDefaults(t *testing.T) {
 		}
 		if cfg.Cache.MaxSize == 0 {
 			t.Error("Cache.MaxSize should be defaulted, got 0")
+		}
+	})
+}
+
+func TestParseFlagsDebianSecurityMirror(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv(EnvDebianSecurity, "https://env.example.com/debian-security/")
+	withArgs(t, []string{"apt-proxy", "--debian-security=https://cli.example.com/debian-security/"}, func() {
+		cfg, err := ParseFlags()
+		if err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		if got, want := cfg.Mirrors.DebianSecurity, "https://cli.example.com/debian-security/"; got != want {
+			t.Fatalf("DebianSecurity = %q, want CLI value %q", got, want)
 		}
 	})
 }

--- a/internal/config/loader_flags.go
+++ b/internal/config/loader_flags.go
@@ -76,6 +76,7 @@ func defineFlags(flags *flag.FlagSet) {
 	flags.String("ubuntu", "", "the ubuntu mirror for fetching packages")
 	flags.String("ubuntu-ports", "", "the ubuntu ports mirror for fetching packages")
 	flags.String("debian", "", "the debian mirror for fetching packages")
+	flags.String("debian-security", "", "the Debian security mirror for fetching security updates")
 	flags.String("centos", "", "the centos mirror for fetching packages")
 	flags.String("alpine", "", "the alpine mirror for fetching packages")
 	flags.String("distributions-config", "", "path to distributions YAML (distributions.yaml)")
@@ -143,7 +144,7 @@ var flagGroups = []struct {
 	},
 	{
 		title: "Mirrors",
-		flags: []string{"ubuntu", "ubuntu-ports", "debian", "centos", "alpine"},
+		flags: []string{"ubuntu", "ubuntu-ports", "debian", "debian-security", "centos", "alpine"},
 	},
 	{
 		title: "TLS",
@@ -250,6 +251,7 @@ type cliExplicit struct {
 	UbuntuMirror          bool
 	UbuntuPortsMirror     bool
 	DebianMirror          bool
+	DebianSecurityMirror  bool
 	CentOSMirror          bool
 	AlpineMirror          bool
 	CacheMaxSize          bool
@@ -315,6 +317,7 @@ func buildCLIConfig(flags *flag.FlagSet, defaultHost, defaultPort, defaultCacheD
 		UbuntuMirror:          flagOrEnvSet(flags, "ubuntu", EnvUbuntu),
 		UbuntuPortsMirror:     flagOrEnvSet(flags, "ubuntu-ports", EnvUbuntuPorts),
 		DebianMirror:          flagOrEnvSet(flags, "debian", EnvDebian),
+		DebianSecurityMirror:  flagOrEnvSet(flags, "debian-security", EnvDebianSecurity),
 		CentOSMirror:          flagOrEnvSet(flags, "centos", EnvCentOS),
 		AlpineMirror:          flagOrEnvSet(flags, "alpine", EnvAlpine),
 		CacheMaxSize:          flagOrEnvSet(flags, "cache-max-size", EnvCacheMaxSize),
@@ -362,6 +365,7 @@ func buildCLIConfig(flags *flag.FlagSet, defaultHost, defaultPort, defaultCacheD
 	ubuntu := configutil.ResolveString(flags, "ubuntu", EnvUbuntu, "", true)
 	ubuntuPorts := configutil.ResolveString(flags, "ubuntu-ports", EnvUbuntuPorts, "", true)
 	debian := configutil.ResolveString(flags, "debian", EnvDebian, "", true)
+	debianSecurity := configutil.ResolveString(flags, "debian-security", EnvDebianSecurity, "", true)
 	centos := configutil.ResolveString(flags, "centos", EnvCentOS, "", true)
 	alpine := configutil.ResolveString(flags, "alpine", EnvAlpine, "", true)
 
@@ -418,11 +422,12 @@ func buildCLIConfig(flags *flag.FlagSet, defaultHost, defaultPort, defaultCacheD
 		CacheDir:          cacheDir,
 		UpstreamKeepAlive: upstreamKeepAlive,
 		Mirrors: MirrorConfig{
-			Ubuntu:      ubuntu,
-			UbuntuPorts: ubuntuPorts,
-			Debian:      debian,
-			CentOS:      centos,
-			Alpine:      alpine,
+			Ubuntu:         ubuntu,
+			UbuntuPorts:    ubuntuPorts,
+			Debian:         debian,
+			DebianSecurity: debianSecurity,
+			CentOS:         centos,
+			Alpine:         alpine,
 		},
 		Cache: CacheConfig{
 			MaxSize:         cacheMaxSizeGB * 1024 * 1024 * 1024,

--- a/internal/config/loader_merge.go
+++ b/internal/config/loader_merge.go
@@ -53,6 +53,9 @@ func MergeConfigsWithExplicit(base, override *Config, ex *cliExplicit) *Config {
 	if ex.DebianMirror {
 		result.Mirrors.Debian = override.Mirrors.Debian
 	}
+	if ex.DebianSecurityMirror {
+		result.Mirrors.DebianSecurity = override.Mirrors.DebianSecurity
+	}
 	if ex.CentOSMirror {
 		result.Mirrors.CentOS = override.Mirrors.CentOS
 	}
@@ -180,6 +183,9 @@ func MergeConfigs(base, override *Config) *Config {
 	}
 	if override.Mirrors.Debian != "" {
 		result.Mirrors.Debian = override.Mirrors.Debian
+	}
+	if override.Mirrors.DebianSecurity != "" {
+		result.Mirrors.DebianSecurity = override.Mirrors.DebianSecurity
 	}
 	if override.Mirrors.CentOS != "" {
 		result.Mirrors.CentOS = override.Mirrors.CentOS

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -41,6 +41,7 @@ cache:
 mirrors:
   ubuntu: "https://mirrors.test.com/ubuntu"
   debian: "https://mirrors.test.com/debian"
+  debian_security: "https://security.test.com/debian-security"
 
 tls:
   enabled: true
@@ -97,6 +98,9 @@ mode: "ubuntu"
 	}
 	if cfg.Mirrors.Debian != "https://mirrors.test.com/debian" {
 		t.Errorf("expected Debian mirror 'https://mirrors.test.com/debian', got '%s'", cfg.Mirrors.Debian)
+	}
+	if cfg.Mirrors.DebianSecurity != "https://security.test.com/debian-security" {
+		t.Errorf("expected Debian security mirror, got %q", cfg.Mirrors.DebianSecurity)
 	}
 
 	// Verify TLS config
@@ -221,8 +225,9 @@ func TestMergeConfigs(t *testing.T) {
 		Listen:   "0.0.0.0:3142",
 		Mode:     1,
 		Mirrors: MirrorConfig{
-			Ubuntu: "https://base.ubuntu.com",
-			Debian: "https://base.debian.org",
+			Ubuntu:         "https://base.ubuntu.com",
+			Debian:         "https://base.debian.org",
+			DebianSecurity: "https://base.security.debian.org/debian-security/",
 		},
 		Cache: CacheConfig{
 			MaxSize: 10 * 1024 * 1024 * 1024,
@@ -235,7 +240,8 @@ func TestMergeConfigs(t *testing.T) {
 		CacheDir: "",   // Don't override (empty)
 		Listen:   "127.0.0.1:8080",
 		Mirrors: MirrorConfig{
-			Ubuntu: "https://override.ubuntu.com", // Override
+			Ubuntu:         "https://override.ubuntu.com", // Override
+			DebianSecurity: "https://override.security.debian.org/debian-security/",
 			// Debian not set, should keep base
 		},
 		Cache: CacheConfig{
@@ -262,6 +268,9 @@ func TestMergeConfigs(t *testing.T) {
 	}
 	if result.Mirrors.Debian != "https://base.debian.org" {
 		t.Errorf("Debian mirror should be kept from base, got '%s'", result.Mirrors.Debian)
+	}
+	if result.Mirrors.DebianSecurity != "https://override.security.debian.org/debian-security/" {
+		t.Errorf("Debian security mirror should be overridden, got %q", result.Mirrors.DebianSecurity)
 	}
 	if result.Cache.MaxSize != 20*1024*1024*1024 {
 		t.Errorf("Cache.MaxSize should be overridden, got %d", result.Cache.MaxSize)

--- a/internal/config/loader_validate.go
+++ b/internal/config/loader_validate.go
@@ -46,6 +46,7 @@ func ApplyToState(config *Config, st *state.AppState, reg *distro.Registry) erro
 	st.SetMirrorWithRegistry(distro.TypeUbuntu, config.Mirrors.Ubuntu, reg)
 	st.SetMirrorWithRegistry(distro.TypeUbuntuPorts, config.Mirrors.UbuntuPorts, reg)
 	st.SetMirrorWithRegistry(distro.TypeDebian, config.Mirrors.Debian, reg)
+	st.SetDebianSecurityMirrorWithRegistry(config.Mirrors.DebianSecurity, reg)
 	st.SetMirrorWithRegistry(distro.TypeCentOS, config.Mirrors.CentOS, reg)
 	st.SetMirrorWithRegistry(distro.TypeAlpine, config.Mirrors.Alpine, reg)
 	return nil

--- a/internal/config/loader_yaml.go
+++ b/internal/config/loader_yaml.go
@@ -43,11 +43,12 @@ type YAMLConfig struct {
 	} `yaml:"cache"`
 
 	Mirrors struct {
-		Ubuntu      string `yaml:"ubuntu"`
-		UbuntuPorts string `yaml:"ubuntu_ports"`
-		Debian      string `yaml:"debian"`
-		CentOS      string `yaml:"centos"`
-		Alpine      string `yaml:"alpine"`
+		Ubuntu         string `yaml:"ubuntu"`
+		UbuntuPorts    string `yaml:"ubuntu_ports"`
+		Debian         string `yaml:"debian"`
+		DebianSecurity string `yaml:"debian_security"`
+		CentOS         string `yaml:"centos"`
+		Alpine         string `yaml:"alpine"`
 	} `yaml:"mirrors"`
 
 	TLS struct {
@@ -164,11 +165,12 @@ func yamlConfigToConfig(yamlCfg *YAMLConfig) *Config {
 		Debug:    yamlCfg.Server.Debug,
 		CacheDir: yamlCfg.Cache.Dir,
 		Mirrors: MirrorConfig{
-			Ubuntu:      yamlCfg.Mirrors.Ubuntu,
-			UbuntuPorts: yamlCfg.Mirrors.UbuntuPorts,
-			Debian:      yamlCfg.Mirrors.Debian,
-			CentOS:      yamlCfg.Mirrors.CentOS,
-			Alpine:      yamlCfg.Mirrors.Alpine,
+			Ubuntu:         yamlCfg.Mirrors.Ubuntu,
+			UbuntuPorts:    yamlCfg.Mirrors.UbuntuPorts,
+			Debian:         yamlCfg.Mirrors.Debian,
+			DebianSecurity: yamlCfg.Mirrors.DebianSecurity,
+			CentOS:         yamlCfg.Mirrors.CentOS,
+			Alpine:         yamlCfg.Mirrors.Alpine,
 		},
 		Cache: CacheConfig{
 			MaxSizeGB:          yamlCfg.Cache.MaxSizeGB,

--- a/internal/proxy/rewriter.go
+++ b/internal/proxy/rewriter.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 
 	logger "github.com/soulteary/logger-kit/v2"
@@ -32,8 +33,40 @@ import (
 
 // URLRewriter holds the mirror and pattern for URL rewriting
 type URLRewriter struct {
-	mirror  *url.URL
-	pattern *regexp.Regexp
+	mirror         *url.URL
+	securityMirror *url.URL
+	pattern        *regexp.Regexp
+}
+
+func debianSecurityMirror(archive, configured *url.URL) *url.URL {
+	source := configured
+	if source == nil {
+		source = archive
+	}
+	if source == nil {
+		return nil
+	}
+
+	security := *source
+	path := strings.TrimSuffix(security.Path, "/")
+	switch {
+	case strings.HasSuffix(path, "/debian-security"):
+		// Already points at the security archive.
+	case strings.HasSuffix(path, "/debian"):
+		path = strings.TrimSuffix(path, "/debian") + "/debian-security"
+	default:
+		path += "/debian-security"
+	}
+	security.Path = path + "/"
+	security.RawPath = ""
+	return &security
+}
+
+func attachDebianSecurityMirror(mode int, st *state.AppState, rewriter *URLRewriter) *URLRewriter {
+	if mode == distro.TypeDebian && rewriter != nil {
+		rewriter.securityMirror = debianSecurityMirror(rewriter.mirror, st.GetDebianSecurityMirror())
+	}
+	return rewriter
 }
 
 // URLRewriters manages rewriters for different distributions
@@ -164,7 +197,7 @@ func createRewriter(mode int, st *state.AppState, reg *distro.Registry, bench *b
 	if mirror != nil {
 		log.Info().Str("distro", name).Str("mirror", mirror.String()).Msg("using specified mirror")
 		rewriter.mirror = mirror
-		return rewriter
+		return attachDebianSecurityMirror(mode, st, rewriter)
 	}
 
 	mirrorURLs := mirrors.GetGeoMirrorUrlsByMode(reg, mode)
@@ -180,7 +213,7 @@ func createRewriter(mode int, st *state.AppState, reg *distro.Registry, bench *b
 		rewriter.mirror = mirror
 	}
 
-	return rewriter
+	return attachDebianSecurityMirror(mode, st, rewriter)
 }
 
 // createRewriterAsync creates a new URLRewriter for a specific distribution using async benchmark.
@@ -201,7 +234,7 @@ func createRewriterAsync(mode int, st *state.AppState, reg *distro.Registry, rew
 	if mirror != nil {
 		log.Info().Str("distro", name).Str("mirror", mirror.String()).Msg("using specified mirror")
 		rewriter.mirror = mirror
-		return rewriter
+		return attachDebianSecurityMirror(mode, st, rewriter)
 	}
 
 	mirrorURLs := mirrors.GetGeoMirrorUrlsByMode(reg, mode)
@@ -211,7 +244,7 @@ func createRewriterAsync(mode int, st *state.AppState, reg *distro.Registry, rew
 		if parsedMirror, err := url.Parse(cached); err == nil {
 			log.Info().Str("distro", name).Str("mirror", cached).Msg("using cached mirror")
 			rewriter.mirror = parsedMirror
-			return rewriter
+			return attachDebianSecurityMirror(mode, st, rewriter)
 		}
 	}
 
@@ -220,6 +253,7 @@ func createRewriterAsync(mode int, st *state.AppState, reg *distro.Registry, rew
 		log.Info().Str("distro", name).Str("mirror", defaultMirror).Msg("using default mirror (async benchmark pending)")
 		rewriter.mirror = parsedMirror
 	}
+	attachDebianSecurityMirror(mode, st, rewriter)
 
 	// Run benchmark in background and update when complete.
 	//
@@ -251,7 +285,11 @@ func createRewriterAsync(mode int, st *state.AppState, reg *distro.Registry, rew
 		// concurrent RefreshRewriters cannot accidentally lose its newer
 		// pattern when this stale callback fires.
 		oldPattern := (*p).pattern
-		*p = &URLRewriter{mirror: parsedMirror, pattern: oldPattern}
+		securityMirror := (*p).securityMirror
+		if mode == distro.TypeDebian && st.GetDebianSecurityMirror() == nil {
+			securityMirror = debianSecurityMirror(parsedMirror, nil)
+		}
+		*p = &URLRewriter{mirror: parsedMirror, securityMirror: securityMirror, pattern: oldPattern}
 		rewriters.Mu.Unlock()
 
 		log.Info().Str("distro", name).Str("mirror", result.FastestMirror).Msg("async benchmark completed, mirror updated")
@@ -355,10 +393,15 @@ func RewriteRequestByMode(r *http.Request, rewriters *URLRewriters, mode int) {
 		suffixPath = suffixRaw
 	}
 
-	r.URL.Scheme = rewriter.mirror.Scheme
-	r.URL.Host = rewriter.mirror.Host
-	r.URL.Path = rewriter.mirror.Path + suffixPath
-	rawPath := rewriter.mirror.EscapedPath() + suffixRaw
+	target := rewriter.mirror
+	if mode == distro.TypeDebian && strings.HasPrefix(escapedPath, "/debian-security/") && rewriter.securityMirror != nil {
+		target = rewriter.securityMirror
+	}
+
+	r.URL.Scheme = target.Scheme
+	r.URL.Host = target.Host
+	r.URL.Path = target.Path + suffixPath
+	rawPath := target.EscapedPath() + suffixRaw
 	if rawPath != r.URL.Path {
 		r.URL.RawPath = rawPath
 	} else {

--- a/internal/proxy/rewriter_test.go
+++ b/internal/proxy/rewriter_test.go
@@ -144,13 +144,14 @@ func TestRewriteRequestByMode(t *testing.T) {
 // the mirror path prefix.
 func TestRewriteRequestByModePathPrefix(t *testing.T) {
 	cases := []struct {
-		name     string
-		mirror   string
-		mode     int
-		distType int
-		path     string
-		wantHost string
-		wantPath string
+		name           string
+		mirror         string
+		securityMirror string
+		mode           int
+		distType       int
+		path           string
+		wantHost       string
+		wantPath       string
 	}{
 		{
 			name:     "ubuntu with sub-path mirror",
@@ -171,13 +172,33 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			wantPath: "/repo/debian/dists/bookworm/Release",
 		},
 		{
-			name:     "debian-security routed via security mirror",
+			name:           "regular debian keeps archive mirror",
+			mirror:         "http://archive.example.com/debian/",
+			securityMirror: "http://security.example.com/debian-security/",
+			mode:           distro.TypeDebian,
+			distType:       distro.TypeDebian,
+			path:           "/debian/dists/bookworm/Release",
+			wantHost:       "archive.example.com",
+			wantPath:       "/debian/dists/bookworm/Release",
+		},
+		{
+			name:           "debian-security routed via dedicated mirror",
+			mirror:         "http://archive.example.com/debian/",
+			securityMirror: "http://security.example.com/debian-security/",
+			mode:           distro.TypeDebian,
+			distType:       distro.TypeDebian,
+			path:           "/debian-security/dists/bookworm-security/main/binary-amd64/Release",
+			wantHost:       "security.example.com",
+			wantPath:       "/debian-security/dists/bookworm-security/main/binary-amd64/Release",
+		},
+		{
+			name:     "debian-security derived without duplicate suffix",
 			mirror:   "http://security.example.com/debian-security/",
 			mode:     distro.TypeDebian,
 			distType: distro.TypeDebian,
-			path:     "/debian-security/dists/bookworm-security/main/binary-amd64/Release",
+			path:     "/debian-security/dists/bookworm-security/Release",
 			wantHost: "security.example.com",
-			wantPath: "/debian-security/dists/bookworm-security/main/binary-amd64/Release",
+			wantPath: "/debian-security/dists/bookworm-security/Release",
 		},
 	}
 
@@ -186,6 +207,7 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			st := state.NewAppState()
 			reg := newTestRegistry()
 			st.SetMirror(tc.distType, tc.mirror)
+			st.SetDebianSecurityMirrorWithRegistry(tc.securityMirror, reg)
 
 			rewriters := CreateNewRewriters(tc.mode, st, reg)
 			req, err := http.NewRequest("GET", "http://localhost"+tc.path, nil)

--- a/internal/state/app.go
+++ b/internal/state/app.go
@@ -109,23 +109,25 @@ func (m *MirrorState) Clone() *MirrorState {
 // AppState manages the complete runtime state for a single Server: the
 // proxy mode and the mirror configuration for every supported distro.
 type AppState struct {
-	proxyMode   atomic.Int64
-	Ubuntu      *MirrorState
-	UbuntuPorts *MirrorState
-	Debian      *MirrorState
-	CentOS      *MirrorState
-	Alpine      *MirrorState
+	proxyMode      atomic.Int64
+	Ubuntu         *MirrorState
+	UbuntuPorts    *MirrorState
+	Debian         *MirrorState
+	DebianSecurity *MirrorState
+	CentOS         *MirrorState
+	Alpine         *MirrorState
 }
 
 // NewAppState constructs a fresh AppState with empty MirrorStates for
 // every supported distro.
 func NewAppState() *AppState {
 	return &AppState{
-		Ubuntu:      NewMirrorState(distro.TypeUbuntu),
-		UbuntuPorts: NewMirrorState(distro.TypeUbuntuPorts),
-		Debian:      NewMirrorState(distro.TypeDebian),
-		CentOS:      NewMirrorState(distro.TypeCentOS),
-		Alpine:      NewMirrorState(distro.TypeAlpine),
+		Ubuntu:         NewMirrorState(distro.TypeUbuntu),
+		UbuntuPorts:    NewMirrorState(distro.TypeUbuntuPorts),
+		Debian:         NewMirrorState(distro.TypeDebian),
+		DebianSecurity: NewMirrorState(distro.TypeDebian),
+		CentOS:         NewMirrorState(distro.TypeCentOS),
+		Alpine:         NewMirrorState(distro.TypeAlpine),
 	}
 }
 
@@ -162,6 +164,18 @@ func (s *AppState) GetMirror(distType int) *url.URL {
 	return nil
 }
 
+// SetDebianSecurityMirrorWithRegistry sets the optional dedicated upstream
+// used for /debian-security/ requests. Debian aliases are accepted and their
+// archive path is normalized by the proxy rewriter.
+func (s *AppState) SetDebianSecurityMirrorWithRegistry(input string, reg *distro.Registry) {
+	s.DebianSecurity.SetWithRegistry(input, reg)
+}
+
+// GetDebianSecurityMirror returns the dedicated Debian security upstream.
+func (s *AppState) GetDebianSecurityMirror() *url.URL {
+	return s.DebianSecurity.Get()
+}
+
 // mirrorByType returns the *MirrorState backing the given distro type,
 // or nil for unknown types. Centralising the switch avoids drift between
 // SetMirror/GetMirror/ResetAll.
@@ -187,6 +201,7 @@ func (s *AppState) ResetAll() {
 	s.Ubuntu.Reset()
 	s.UbuntuPorts.Reset()
 	s.Debian.Reset()
+	s.DebianSecurity.Reset()
 	s.CentOS.Reset()
 	s.Alpine.Reset()
 }
@@ -195,11 +210,12 @@ func (s *AppState) ResetAll() {
 // mutable state with the original.
 func (s *AppState) Clone() *AppState {
 	clone := &AppState{
-		Ubuntu:      s.Ubuntu.Clone(),
-		UbuntuPorts: s.UbuntuPorts.Clone(),
-		Debian:      s.Debian.Clone(),
-		CentOS:      s.CentOS.Clone(),
-		Alpine:      s.Alpine.Clone(),
+		Ubuntu:         s.Ubuntu.Clone(),
+		UbuntuPorts:    s.UbuntuPorts.Clone(),
+		Debian:         s.Debian.Clone(),
+		DebianSecurity: s.DebianSecurity.Clone(),
+		CentOS:         s.CentOS.Clone(),
+		Alpine:         s.Alpine.Clone(),
 	}
 	clone.proxyMode.Store(s.proxyMode.Load())
 	return clone

--- a/internal/state/app_test.go
+++ b/internal/state/app_test.go
@@ -35,6 +35,9 @@ func TestNewAppState(t *testing.T) {
 	if st.Debian == nil {
 		t.Error("Debian mirror state is nil")
 	}
+	if st.DebianSecurity == nil {
+		t.Error("DebianSecurity mirror state is nil")
+	}
 	if st.CentOS == nil {
 		t.Error("CentOS mirror state is nil")
 	}
@@ -89,6 +92,23 @@ func TestAppStateSetMirrorUnknownType(t *testing.T) {
 	st.SetMirror(9999, "https://mirrors.example.com/whatever/")
 	if got := st.GetMirror(9999); got != nil {
 		t.Errorf("GetMirror(9999) = %q, want nil", got.String())
+	}
+}
+
+func TestAppStateDebianSecurityMirror(t *testing.T) {
+	st := NewAppState()
+	const mirror = "https://security.example.com/debian-security/"
+	st.SetDebianSecurityMirrorWithRegistry(mirror, nil)
+	if got := st.GetDebianSecurityMirror(); got == nil || got.String() != mirror {
+		t.Fatalf("GetDebianSecurityMirror() = %v, want %q", got, mirror)
+	}
+	clone := st.Clone()
+	if got := clone.GetDebianSecurityMirror(); got == nil || got.String() != mirror {
+		t.Fatalf("clone security mirror = %v, want %q", got, mirror)
+	}
+	st.ResetAll()
+	if got := st.GetDebianSecurityMirror(); got != nil {
+		t.Fatalf("security mirror after ResetAll = %v, want nil", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a dedicated Debian Security mirror alongside the regular Debian archive
- expose it through `--debian-security`, `APT_PROXY_DEBIAN_SECURITY`, and YAML `mirrors.debian_security`
- route `/debian/` and `/debian-security/` to different hosts when configured
- preserve arbitrary paths on explicitly configured Debian Security mirrors
- derive `/debian-security/` safely from the normal Debian mirror only when the dedicated mirror is omitted
- avoid duplicating the suffix when a fallback mirror already ends in `/debian-security/`
- preserve async benchmark refresh behavior and runtime state isolation
- document the new CLI, ENV, and YAML configuration

This replaces the flawed Debian Security path concatenation in #58 with a separate, backward-compatible configuration path. It intentionally does not remove `Range` headers or disable HTTP/2.

The PR is based directly on `main` after #80 was merged.

## Verification

- `go test -race -short -count=1 ./...`
- `go test -race ./internal/proxy ./internal/config ./internal/state`
- `go vet ./...`
- regression coverage for separate archive/security hosts, explicit arbitrary roots, derived paths, suffix de-duplication, YAML, CLI/ENV, merge, clone, and reset behavior