### PR TITLE
fix: preserve Ubuntu geo mirror discovery

### DIFF
--- a/internal/distro/registry.go
+++ b/internal/distro/registry.go
@@ -39,6 +39,7 @@ type RegisteredDistribution struct {
 	ID           string
 	Name         string
 	Type         int
+	Builtin      bool
 	URLPattern   *regexp.Regexp
 	BenchmarkURL string
 	GeoMirrorAPI string
@@ -193,6 +194,7 @@ func RegisterBuiltins(reg *Registry) {
 			ID:           DistroUbuntu,
 			Name:         "Ubuntu",
 			Type:         TypeUbuntu,
+			Builtin:      true,
 			URLPattern:   UbuntuHostPattern,
 			BenchmarkURL: UbuntuBenchmarkURL,
 			GeoMirrorAPI: UbuntuGeoMirrorAPI,
@@ -203,6 +205,7 @@ func RegisterBuiltins(reg *Registry) {
 			ID:           DistroUbuntuPorts,
 			Name:         "Ubuntu Ports",
 			Type:         TypeUbuntuPorts,
+			Builtin:      true,
 			URLPattern:   UbuntuPortsHostPattern,
 			BenchmarkURL: UbuntuPortsBenchmarkURL,
 			GeoMirrorAPI: UbuntuPortsGeoMirrorAPI,
@@ -213,6 +216,7 @@ func RegisterBuiltins(reg *Registry) {
 			ID:           DistroDebian,
 			Name:         "Debian",
 			Type:         TypeDebian,
+			Builtin:      true,
 			URLPattern:   DebianHostPattern,
 			BenchmarkURL: DebianBenchmarkURL,
 			CacheRules:   DebianDefaultCacheRules,
@@ -222,6 +226,7 @@ func RegisterBuiltins(reg *Registry) {
 			ID:           DistroCentOS,
 			Name:         "CentOS",
 			Type:         TypeCentOS,
+			Builtin:      true,
 			URLPattern:   CentosHostPattern,
 			BenchmarkURL: CentosBenchmarkURL,
 			CacheRules:   CentosDefaultCacheRules,
@@ -231,6 +236,7 @@ func RegisterBuiltins(reg *Registry) {
 			ID:           DistroAlpine,
 			Name:         "Alpine Linux",
 			Type:         TypeAlpine,
+			Builtin:      true,
 			URLPattern:   AlpineHostPattern,
 			BenchmarkURL: AlpineBenchmarkURL,
 			CacheRules:   AlpineDefaultCacheRules,

--- a/internal/mirrors/mirrors.go
+++ b/internal/mirrors/mirrors.go
@@ -69,18 +69,23 @@ var builtinByMode = map[int]builtinDistro{
 	},
 }
 
+var ubuntuGeoMirrorLookup = GetUbuntuMirrorUrlsByGeo
+
 // GetGeoMirrorUrlsByMode returns the candidate upstream mirror URLs
 // for the given proxy mode. When reg is non-nil, registry-loaded
 // mirrors are preferred over the compile-time built-ins.
 func GetGeoMirrorUrlsByMode(reg *distro.Registry, mode int) (mirrors []string) {
-	// Prefer registry (config-loaded) mirrors when present
+	// Prefer user-configured registry mirrors. The daemon also seeds the
+	// registry with built-ins, which must not suppress Ubuntu geo discovery.
 	if reg != nil {
 		if d, ok := reg.GetByType(mode); ok && len(d.Mirrors) > 0 {
-			for _, m := range d.Mirrors {
-				mirrors = append(mirrors, GetFullMirrorURL(m))
-			}
-			if len(mirrors) > 0 {
-				return mirrors
+			if mode != distro.TypeUbuntu || !d.Builtin {
+				for _, m := range d.Mirrors {
+					mirrors = append(mirrors, GetFullMirrorURL(m))
+				}
+				if len(mirrors) > 0 {
+					return mirrors
+				}
 			}
 		}
 	}
@@ -89,7 +94,7 @@ func GetGeoMirrorUrlsByMode(reg *distro.Registry, mode int) (mirrors []string) {
 	// guarantee that those hosts also publish the distinct ubuntu-ports
 	// archive, so only use geo-discovered candidates for regular Ubuntu.
 	if mode == distro.TypeUbuntu {
-		online, err := GetUbuntuMirrorUrlsByGeo()
+		online, err := ubuntuGeoMirrorLookup()
 		if err == nil && len(online) > 0 {
 			return online
 		}

--- a/internal/mirrors/mirrors_test.go
+++ b/internal/mirrors/mirrors_test.go
@@ -54,6 +54,50 @@ func TestUbuntuPortsUsesDedicatedBuiltins(t *testing.T) {
 	}
 }
 
+func TestUbuntuBuiltinRegistryStillUsesGeoDiscovery(t *testing.T) {
+	want := []string{"https://geo.example.com/ubuntu/"}
+	original := ubuntuGeoMirrorLookup
+	ubuntuGeoMirrorLookup = func() ([]string, error) {
+		return want, nil
+	}
+	t.Cleanup(func() { ubuntuGeoMirrorLookup = original })
+
+	reg := distro.NewBuiltinRegistry()
+	if got := GetGeoMirrorUrlsByMode(reg, distro.TypeUbuntu); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Ubuntu mirrors = %v, want geo-discovered mirrors %v", got, want)
+	}
+}
+
+func TestUbuntuConfiguredRegistryOverridesGeoDiscovery(t *testing.T) {
+	want := []string{"https://configured.example.com/ubuntu/"}
+	called := false
+	original := ubuntuGeoMirrorLookup
+	ubuntuGeoMirrorLookup = func() ([]string, error) {
+		called = true
+		return []string{"https://geo.example.com/ubuntu/"}, nil
+	}
+	t.Cleanup(func() { ubuntuGeoMirrorLookup = original })
+
+	reg := distro.NewRegistry()
+	if err := reg.Register(&distro.RegisteredDistribution{
+		ID:   "ubuntu",
+		Name: "Ubuntu",
+		Type: distro.TypeUbuntu,
+		Mirrors: []distro.URLWithAlias{
+			{URL: want[0], Scheme: "https"},
+		},
+	}); err != nil {
+		t.Fatalf("register Ubuntu: %v", err)
+	}
+
+	if got := GetGeoMirrorUrlsByMode(reg, distro.TypeUbuntu); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Ubuntu mirrors = %v, want configured mirrors %v", got, want)
+	}
+	if called {
+		t.Fatal("geo discovery called despite configured Ubuntu mirrors")
+	}
+}
+
 func TestGetUbuntuMirrorByAliases(t *testing.T) {
 	alias := GetMirrorURLByAliases(nil, distro.TypeUbuntu, "cn:tsinghua")
 	if !strings.Contains(alias, "mirrors.tuna.tsinghua.edu.cn/ubuntu/") {


### PR DESCRIPTION
## Summary

- distinguish built-in distribution entries from user-configured registry entries
- keep user-configured Ubuntu mirrors authoritative
- let the built-in Ubuntu registry continue through `mirrors.txt` geo discovery
- keep Ubuntu Ports restricted to configured or dedicated built-in Ports mirrors
- add deterministic regression tests for both built-in and configured Ubuntu behavior

This follows up the valid automated review on #80. The default daemon seeds a built-in registry, so treating every registry mirror list as an explicit override accidentally disabled Ubuntu geo discovery.

## Verification

- `go test -race ./internal/mirrors ./internal/distro`
- `go test -race -short -count=1 ./...`
- `go vet ./...`
- `git diff --check`