### PR TITLE
fix: preserve configured Debian Security paths

### DIFF
--- a/internal/proxy/rewriter.go
+++ b/internal/proxy/rewriter.go
@@ -38,8 +38,8 @@ type URLRewriter struct {
 	pattern        *regexp.Regexp
 }
 
-func debianSecurityMirror(archive, configured *url.URL) *url.URL {
-	if configured != nil {
+func debianSecurityMirror(archive, configured *url.URL, configuredAlias bool) *url.URL {
+	if configured != nil && !configuredAlias {
 		security := *configured
 		security.Path = strings.TrimSuffix(security.Path, "/") + "/"
 		if security.RawPath != "" {
@@ -47,11 +47,15 @@ func debianSecurityMirror(archive, configured *url.URL) *url.URL {
 		}
 		return &security
 	}
-	if archive == nil {
+	source := archive
+	if configured != nil {
+		source = configured
+	}
+	if source == nil {
 		return nil
 	}
 
-	security := *archive
+	security := *source
 	path := strings.TrimSuffix(security.Path, "/")
 	switch {
 	case strings.HasSuffix(path, "/debian-security"):
@@ -68,7 +72,11 @@ func debianSecurityMirror(archive, configured *url.URL) *url.URL {
 
 func attachDebianSecurityMirror(mode int, st *state.AppState, rewriter *URLRewriter) *URLRewriter {
 	if mode == distro.TypeDebian && rewriter != nil {
-		rewriter.securityMirror = debianSecurityMirror(rewriter.mirror, st.GetDebianSecurityMirror())
+		rewriter.securityMirror = debianSecurityMirror(
+			rewriter.mirror,
+			st.GetDebianSecurityMirror(),
+			st.DebianSecurityMirrorResolvedAlias(),
+		)
 	}
 	return rewriter
 }
@@ -291,7 +299,7 @@ func createRewriterAsync(mode int, st *state.AppState, reg *distro.Registry, rew
 		oldPattern := (*p).pattern
 		securityMirror := (*p).securityMirror
 		if mode == distro.TypeDebian && st.GetDebianSecurityMirror() == nil {
-			securityMirror = debianSecurityMirror(parsedMirror, nil)
+			securityMirror = debianSecurityMirror(parsedMirror, nil, false)
 		}
 		*p = &URLRewriter{mirror: parsedMirror, securityMirror: securityMirror, pattern: oldPattern}
 		rewriters.Mu.Unlock()

--- a/internal/proxy/rewriter.go
+++ b/internal/proxy/rewriter.go
@@ -39,15 +39,19 @@ type URLRewriter struct {
 }
 
 func debianSecurityMirror(archive, configured *url.URL) *url.URL {
-	source := configured
-	if source == nil {
-		source = archive
+	if configured != nil {
+		security := *configured
+		security.Path = strings.TrimSuffix(security.Path, "/") + "/"
+		if security.RawPath != "" {
+			security.RawPath = strings.TrimSuffix(security.RawPath, "/") + "/"
+		}
+		return &security
 	}
-	if source == nil {
+	if archive == nil {
 		return nil
 	}
 
-	security := *source
+	security := *archive
 	path := strings.TrimSuffix(security.Path, "/")
 	switch {
 	case strings.HasSuffix(path, "/debian-security"):

--- a/internal/proxy/rewriter_test.go
+++ b/internal/proxy/rewriter_test.go
@@ -202,6 +202,16 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			wantPath:       "/apt/security/dists/bookworm-security/Release",
 		},
 		{
+			name:           "debian-security alias translates archive path",
+			mirror:         "http://archive.example.com/debian/",
+			securityMirror: "cn:tsinghua",
+			mode:           distro.TypeDebian,
+			distType:       distro.TypeDebian,
+			path:           "/debian-security/dists/bookworm-security/Release",
+			wantHost:       "mirrors.tuna.tsinghua.edu.cn",
+			wantPath:       "/debian-security/dists/bookworm-security/Release",
+		},
+		{
 			name:     "debian-security derived without duplicate suffix",
 			mirror:   "http://security.example.com/debian-security/",
 			mode:     distro.TypeDebian,

--- a/internal/proxy/rewriter_test.go
+++ b/internal/proxy/rewriter_test.go
@@ -192,6 +192,16 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			wantPath:       "/debian-security/dists/bookworm-security/main/binary-amd64/Release",
 		},
 		{
+			name:           "explicit debian-security mirror preserves arbitrary root",
+			mirror:         "http://archive.example.com/debian/",
+			securityMirror: "http://artifactory.example/apt/security",
+			mode:           distro.TypeDebian,
+			distType:       distro.TypeDebian,
+			path:           "/debian-security/dists/bookworm-security/Release",
+			wantHost:       "artifactory.example",
+			wantPath:       "/apt/security/dists/bookworm-security/Release",
+		},
+		{
 			name:     "debian-security derived without duplicate suffix",
 			mirror:   "http://security.example.com/debian-security/",
 			mode:     distro.TypeDebian,

--- a/internal/state/app.go
+++ b/internal/state/app.go
@@ -38,8 +38,13 @@ import (
 // pointer atomically. We never mutate a *url.URL after publishing it, so
 // callers can hold the returned pointer without racing future writers.
 type MirrorState struct {
-	url      atomic.Pointer[url.URL]
+	value    atomic.Pointer[mirrorValue]
 	distType int
+}
+
+type mirrorValue struct {
+	url           *url.URL
+	resolvedAlias bool
 }
 
 // NewMirrorState creates a new MirrorState for the given distro type.
@@ -61,13 +66,15 @@ func (m *MirrorState) Set(input string) {
 // resolution.
 func (m *MirrorState) SetWithRegistry(input string, reg *distro.Registry) {
 	if input == "" {
-		m.url.Store(nil)
+		m.value.Store(nil)
 		return
 	}
 
 	mirror := input
+	resolvedAlias := false
 	if alias := mirrors.GetMirrorURLByAliases(reg, m.distType, input); alias != "" {
 		mirror = alias
+		resolvedAlias = true
 	}
 
 	parsed, err := url.Parse(mirror)
@@ -77,31 +84,44 @@ func (m *MirrorState) SetWithRegistry(input string, reg *distro.Registry) {
 			Int("dist_type", m.distType).
 			Str("input", input).
 			Msg("invalid mirror URL, clearing state")
-		m.url.Store(nil)
+		m.value.Store(nil)
 		return
 	}
-	m.url.Store(parsed)
+	m.value.Store(&mirrorValue{url: parsed, resolvedAlias: resolvedAlias})
 }
 
 // Get returns the current mirror URL, or nil if unset.
 //
 // Callers receive the same *url.URL the writer published; never mutate it.
 func (m *MirrorState) Get() *url.URL {
-	return m.url.Load()
+	if current := m.value.Load(); current != nil {
+		return current.url
+	}
+	return nil
+}
+
+// ResolvedAlias reports whether the current URL came from a registry alias.
+// It is read from the same immutable snapshot as the URL, so callers never
+// observe metadata from a different Set operation.
+func (m *MirrorState) ResolvedAlias() bool {
+	if current := m.value.Load(); current != nil {
+		return current.resolvedAlias
+	}
+	return false
 }
 
 // Reset clears the mirror URL.
 func (m *MirrorState) Reset() {
-	m.url.Store(nil)
+	m.value.Store(nil)
 }
 
 // Clone returns an independent MirrorState that contains a deep copy of
 // the stored URL.
 func (m *MirrorState) Clone() *MirrorState {
 	clone := NewMirrorState(m.distType)
-	if cur := m.url.Load(); cur != nil {
-		urlCopy := *cur
-		clone.url.Store(&urlCopy)
+	if current := m.value.Load(); current != nil {
+		urlCopy := *current.url
+		clone.value.Store(&mirrorValue{url: &urlCopy, resolvedAlias: current.resolvedAlias})
 	}
 	return clone
 }
@@ -174,6 +194,12 @@ func (s *AppState) SetDebianSecurityMirrorWithRegistry(input string, reg *distro
 // GetDebianSecurityMirror returns the dedicated Debian security upstream.
 func (s *AppState) GetDebianSecurityMirror() *url.URL {
 	return s.DebianSecurity.Get()
+}
+
+// DebianSecurityMirrorResolvedAlias reports whether the dedicated security
+// mirror was configured through a Debian registry alias.
+func (s *AppState) DebianSecurityMirrorResolvedAlias() bool {
+	return s.DebianSecurity.ResolvedAlias()
 }
 
 // mirrorByType returns the *MirrorState backing the given distro type,

--- a/internal/state/app_test.go
+++ b/internal/state/app_test.go
@@ -106,9 +106,27 @@ func TestAppStateDebianSecurityMirror(t *testing.T) {
 	if got := clone.GetDebianSecurityMirror(); got == nil || got.String() != mirror {
 		t.Fatalf("clone security mirror = %v, want %q", got, mirror)
 	}
+	if clone.DebianSecurityMirrorResolvedAlias() {
+		t.Fatal("literal security mirror marked as alias")
+	}
 	st.ResetAll()
 	if got := st.GetDebianSecurityMirror(); got != nil {
 		t.Fatalf("security mirror after ResetAll = %v, want nil", got)
+	}
+}
+
+func TestAppStateDebianSecurityAliasMetadata(t *testing.T) {
+	st := NewAppState()
+	st.SetDebianSecurityMirrorWithRegistry("cn:tsinghua", distro.NewBuiltinRegistry())
+	if !st.DebianSecurityMirrorResolvedAlias() {
+		t.Fatal("Debian security alias metadata was not retained")
+	}
+	if clone := st.Clone(); !clone.DebianSecurityMirrorResolvedAlias() {
+		t.Fatal("clone lost Debian security alias metadata")
+	}
+	st.ResetAll()
+	if st.DebianSecurityMirrorResolvedAlias() {
+		t.Fatal("reset retained Debian security alias metadata")
 	}
 }
 


### PR DESCRIPTION
## Summary

- use an explicitly configured Debian Security mirror path as its repository root
- retain alias provenance atomically with the resolved mirror URL
- translate alias-derived Debian `/debian/` paths to `/debian-security/`
- preserve literal arbitrary roots, including terminal escaped slashes such as `%2F`
- keep `Path` and `RawPath` equivalent while normalizing the joining slash
- derive `/debian-security/` from the regular Debian archive only when no dedicated mirror is set
- add regressions for Artifactory roots, escaped roots, Debian aliases, clone, and reset behavior

This follows up the valid automated reviews on #81 and this PR. #81 was merged before its first review fix reached the branch.

## Verification

- `go test -race -short -count=1 ./...`
- `go test -race ./internal/proxy ./internal/config ./internal/state`
- `go vet ./...`
- `git diff --check`