### PR TITLE
fix: preserve escaped Debian Security roots

### DIFF
--- a/internal/proxy/rewriter.go
+++ b/internal/proxy/rewriter.go
@@ -41,9 +41,16 @@ type URLRewriter struct {
 func debianSecurityMirror(archive, configured *url.URL, configuredAlias bool) *url.URL {
 	if configured != nil && !configuredAlias {
 		security := *configured
-		security.Path = strings.TrimSuffix(security.Path, "/") + "/"
 		if security.RawPath != "" {
 			security.RawPath = strings.TrimSuffix(security.RawPath, "/") + "/"
+			if decoded, err := url.PathUnescape(security.RawPath); err == nil {
+				security.Path = decoded
+			} else {
+				security.RawPath = ""
+				security.Path = strings.TrimSuffix(security.Path, "/") + "/"
+			}
+		} else {
+			security.Path = strings.TrimSuffix(security.Path, "/") + "/"
 		}
 		return &security
 	}

--- a/internal/proxy/rewriter_test.go
+++ b/internal/proxy/rewriter_test.go
@@ -152,6 +152,7 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 		path           string
 		wantHost       string
 		wantPath       string
+		wantRawPath    string
 	}{
 		{
 			name:     "ubuntu with sub-path mirror",
@@ -212,6 +213,17 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			wantPath:       "/debian-security/dists/bookworm-security/Release",
 		},
 		{
+			name:           "explicit debian-security mirror preserves escaped terminal slash",
+			mirror:         "http://archive.example.com/debian/",
+			securityMirror: "http://artifactory.example/repo%2F",
+			mode:           distro.TypeDebian,
+			distType:       distro.TypeDebian,
+			path:           "/debian-security/dists/bookworm-security/Release",
+			wantHost:       "artifactory.example",
+			wantPath:       "/repo//dists/bookworm-security/Release",
+			wantRawPath:    "/repo%2F/dists/bookworm-security/Release",
+		},
+		{
 			name:     "debian-security derived without duplicate suffix",
 			mirror:   "http://security.example.com/debian-security/",
 			mode:     distro.TypeDebian,
@@ -241,6 +253,9 @@ func TestRewriteRequestByModePathPrefix(t *testing.T) {
 			}
 			if req.URL.Path != tc.wantPath {
 				t.Errorf("Path = %q, want %q", req.URL.Path, tc.wantPath)
+			}
+			if req.URL.RawPath != tc.wantRawPath {
+				t.Errorf("RawPath = %q, want %q", req.URL.RawPath, tc.wantRawPath)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- normalize a configured security mirror's escaped path before joining request suffixes
- derive the decoded `Path` from normalized `RawPath` so Go retains the escaped representation
- preserve roots ending in encoded separators such as `/repo%2F`
- add regression assertions for both decoded `Path` and exact `RawPath`

This follows up the valid automated review on #83, which was merged before this final review fix reached its branch.

## Verification

- `go test -race ./internal/proxy ./internal/state ./internal/config`
- `go vet ./...`
- `git diff --check`