### PR TITLE
fix: support host-prefixed Debian repository paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,22 @@ apk update
 
 ## Advanced Configuration
 
+### apt-cacher-ng-style host-prefixed paths
+
+For known distributions, apt-proxy accepts the host-prefixed path form commonly
+used with apt-cacher-ng. For example:
+
+```text
+deb http://apt-proxy.example:3142/ftp.uni-kl.de/debian bookworm main
+```
+
+The embedded hostname is a compatibility prefix only. A request such as
+`/ftp.uni-kl.de/debian/dists/bookworm/InRelease` is routed to the Debian mirror
+configured in apt-proxy; it does **not** grant access to `ftp.uni-kl.de` or turn
+the service into an unrestricted origin proxy. Host-prefixed
+`/security.debian.org/debian-security/...` paths use the configured dedicated
+Debian Security mirror. Query parameters are preserved, and paths that do not
+match a configured distribution return `404`.
 ### Distributions and Mirrors Config (distributions.yaml)
 
 You can maintain distributions and mirror lists via an external YAML file without changing code or recompiling.

--- a/README_CN.md
+++ b/README_CN.md
@@ -154,6 +154,20 @@ apk update
 
 ## 高级配置
 
+### apt-cacher-ng 风格的主机名前缀路径
+
+对于已知发行版，apt-proxy 兼容 apt-cacher-ng 常用的主机名前缀路径形式。例如：
+
+```text
+deb http://apt-proxy.example:3142/ftp.uni-kl.de/debian bookworm main
+```
+
+路径中的主机名仅作为兼容前缀。
+`/ftp.uni-kl.de/debian/dists/bookworm/InRelease` 这类请求仍会被路由到
+apt-proxy 中配置的 Debian 镜像；它不会授权访问 `ftp.uni-kl.de`，也不会将服务
+变成不受限制的来源代理。带主机名前缀的
+`/security.debian.org/debian-security/...` 路径会使用单独配置的 Debian
+Security 镜像。查询参数会被保留，无法匹配已配置发行版的路径返回 `404`。
 ### 发行版与镜像配置文件（distributions.yaml）
 
 通过外部 YAML 文件可维护发行版和镜像列表，无需改代码或重新编译。

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -248,6 +248,85 @@ func TestProductionProxyRouteRewritesAndCachesAlpineIndex(t *testing.T) {
 	}
 }
 
+func TestProductionProxyRouteSupportsHostPrefixedDebianPaths(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestPath  string
+		upstreamPath string
+	}{
+		{
+			name:         "archive",
+			requestPath:  "/ftp.uni-kl.de/debian/dists/bookworm/InRelease?arch=amd64",
+			upstreamPath: "/debian/dists/bookworm/InRelease",
+		},
+		{
+			name:         "security",
+			requestPath:  "/security.debian.org/debian-security/dists/bookworm-security/InRelease?arch=amd64",
+			upstreamPath: "/debian-security/dists/bookworm-security/InRelease",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var upstreamHits atomic.Int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHits.Add(1)
+				if got := r.URL.Path; got != tt.upstreamPath {
+					t.Errorf("upstream path = %q, want %q", got, tt.upstreamPath)
+				}
+				if got, want := r.URL.RawQuery, "arch=amd64"; got != want {
+					t.Errorf("upstream query = %q, want %q", got, want)
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = io.WriteString(w, "debian-release")
+			}))
+			defer upstream.Close()
+
+			srv, err := NewServer(&config.Config{
+				CacheDir: t.TempDir(),
+				Mode:     distro.TypeDebian,
+				Listen:   "127.0.0.1:0",
+				Mirrors: config.MirrorConfig{
+					Debian:         upstream.URL + "/debian/",
+					DebianSecurity: upstream.URL + "/debian-security/",
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+			t.Cleanup(func() { _ = srv.shutdown() })
+
+			request := func() *http.Response {
+				t.Helper()
+				req := httptest.NewRequest(http.MethodGet, tt.requestPath, nil)
+				resp, err := srv.app.Test(req)
+				if err != nil {
+					t.Fatalf("app.Test: %v", err)
+				}
+				return resp
+			}
+
+			for index, wantCache := range []string{"MISS", "HIT"} {
+				resp := request()
+				body, err := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				if err != nil {
+					t.Fatalf("read response %d: %v", index+1, err)
+				}
+				if resp.StatusCode != http.StatusOK || string(body) != "debian-release" {
+					t.Fatalf("response %d: status=%d body=%q", index+1, resp.StatusCode, body)
+				}
+				if got := resp.Header.Get("X-Cache"); got != wantCache {
+					t.Fatalf("response %d X-Cache = %q, want %s", index+1, got, wantCache)
+				}
+			}
+			if got := upstreamHits.Load(); got != 1 {
+				t.Fatalf("upstream hits = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestServerInitialize(t *testing.T) {
 	// Create a temporary cache directory
 	tmpDir, err := os.MkdirTemp("", "apt-proxy-test-*")

--- a/internal/proxy/rewriter.go
+++ b/internal/proxy/rewriter.go
@@ -413,7 +413,11 @@ func RewriteRequestByMode(r *http.Request, rewriters *URLRewriters, mode int) {
 	}
 
 	target := rewriter.mirror
-	if mode == distro.TypeDebian && strings.HasPrefix(escapedPath, "/debian-security/") && rewriter.securityMirror != nil {
+	// matches[0] is the full distribution path selected by the rewrite pattern.
+	// Check it instead of the complete request path so apt-cacher-ng-style host
+	// prefixes (for example /security.debian.org/debian-security/...) still use
+	// the dedicated Debian Security mirror.
+	if mode == distro.TypeDebian && strings.HasPrefix(matches[0], "/debian-security/") && rewriter.securityMirror != nil {
 		target = rewriter.securityMirror
 	}
 


### PR DESCRIPTION
## Summary

- add the exact apt-cacher-ng-style archive path reported in #60
- route host-prefixed Debian Security paths to the dedicated security mirror
- preserve query strings and verify MISS-to-HIT cache behavior for both archive and security paths
- document that embedded hostnames are compatibility prefixes, not unrestricted upstream destinations
- keep the English and Chinese READMEs aligned

This supersedes #86, which was based on main before #85 and #87 were merged and consequently conflicted with both files.

Closes #60